### PR TITLE
Refine file I/O error handling

### DIFF
--- a/src/Esat.cxx
+++ b/src/Esat.cxx
@@ -37,16 +37,17 @@ int main(int argc, char** argv){
   
   char mtl[16], mdl[16], sol[16], hst[16], active[16];
   nanosphere ns;
-  fstream nano, res3;  
+  ifstream nano("../data/input/nanosphere_eV.dat");
+  if (!nano) {
+      cerr << "Error: Cannot open input file" << endl;
+      return 1;
+  }
   if (argv[1]==0){
       cout<<endl<<"  Usage: "<<argv[0]<<" <G/Gth>"<<endl<<endl;
       exit(0);
       }
   alpha=atof(argv[1]);
   
-  nano.open("../data/input/nanosphere_eV.dat", ios::in);
-
-    
   nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
 
   ns.init();

--- a/src/QS_OB_anl_time.cxx
+++ b/src/QS_OB_anl_time.cxx
@@ -57,15 +57,41 @@ int main(int argc, char** argv){
     char mtl[16], mdl[16], sol[16], active[16];
     double t, dt=0.001, T, to, t0=0., tpump;
     nanosphere ns;
-    fstream nano, time, comp, stat, lmda, dyna, omga;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
-    stat.open("../data/output/stationary.dat", ios::out);
-    lmda.open("../data/output/lambda.dat", ios::out);
-    comp.open("../data/output/compounds.dat", ios::out);
-    dyna.open("../data/output/QS_OB_anltime.dat", ios::out);
-    omga.open("../data/output/omega.dat", ios::out);
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream stat("../data/output/stationary.dat");
+    if (!stat) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream lmda("../data/output/lambda.dat");
+    if (!lmda) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream comp("../data/output/compounds.dat");
+    if (!comp) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream dyna("../data/output/QS_OB_anltime.dat");
+    if (!dyna) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream omga("../data/output/omega.dat");
+    if (!omga) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
 
     omga<<omeeV<<endl;
 

--- a/src/frohlich.cxx
+++ b/src/frohlich.cxx
@@ -37,9 +37,11 @@ int main(){
   
   char mtl[16], mdl[16], sol[16], hst[16], active[16];
   nanosphere ns;
-  fstream nano, res3;  
-  
-  nano.open("../data/input/nanosphere_eV.dat", ios::in);
+  ifstream nano("../data/input/nanosphere_eV.dat");
+  if (!nano) {
+    cerr << "Error: Cannot open input file" << endl;
+    return 1;
+  }
 
   nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
 

--- a/src/lycurguseV_ns.cxx
+++ b/src/lycurguseV_ns.cxx
@@ -40,13 +40,23 @@ int main(){
   char mtl[16], mdl[16], hst[16], active[16], sol[16];
   complex<double> eps, eps1, eps2, eps3, alph;
 
-  fstream nano, comp, resu;
+  ifstream nano("../data/input/nanosphere_eV.dat");
+  if (!nano) {
+    cerr << "Error: Cannot open input file" << endl;
+    return 1;
+  }
+  ofstream resu("../data/output/results.dat");
+  if (!resu) {
+    cerr << "Error: Cannot open output file" << endl;
+    return 1;
+  }
+  ofstream comp("../data/output/compounds.dat");
+  if (!comp) {
+    cerr << "Error: Cannot open output file" << endl;
+    return 1;
+  }
   fstream solv, con1, con2, plb, ps01;
   nanosphere ns;
-  
-  nano.open("../data/input/nanosphere_eV.dat", ios::in);
-  resu.open("../data/output/results.dat", ios::out);
-  comp.open("../data/output/compounds.dat", ios::out);
 
     
   nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>ns.rap>>hst;

--- a/src/nanoshell.cxx
+++ b/src/nanoshell.cxx
@@ -38,11 +38,17 @@ int main(int argc, char** argv){
 
     char mtl[16], mdl[16], hst[16], sol[16], active[16];
     
-    nanosphere ns;    
-    fstream nano, time, spec;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
+    nanosphere ns;
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
 
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     time>>T>>tpump;    

--- a/src/nanoshell_G_p3.cxx
+++ b/src/nanoshell_G_p3.cxx
@@ -157,9 +157,16 @@ int main(){
     
     nanosphere ns;
     
-    fstream nano, emix;
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    emix.open("../data/output/emission_maximum.dat", ios::out);
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream emix("../data/output/emission_maximum.dat");
+    if (!emix) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     

--- a/src/nanoshell_ISS.cxx
+++ b/src/nanoshell_ISS.cxx
@@ -38,11 +38,17 @@ int main(int argc, char** argv){
 
     char mtl[16], mdl[16], hst[16], sol[16], active[16];
     
-    nanosphere ns;    
-    fstream nano, time, spec;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
+    nanosphere ns;
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
 
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     time>>T>>tpump;    

--- a/src/nanoshell_num.cxx
+++ b/src/nanoshell_num.cxx
@@ -43,13 +43,27 @@ int main(int argc, char** argv){
         }
     omeeV=atof(argv[1]);
     
-    nanosphere ns;    
-    fstream nano, time, frlc, omga;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
-    frlc.open("../data/output/frohlich.dat", ios::out);
-    omga.open("../data/output/omega.dat", ios::out);
+    nanosphere ns;
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream frlc("../data/output/frohlich.dat");
+    if (!frlc) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream omga("../data/output/omega.dat");
+    if (!omga) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     time>>T>>tpump;    

--- a/src/nanoshell_num_anl.cxx
+++ b/src/nanoshell_num_anl.cxx
@@ -43,13 +43,27 @@ int main(int argc, char** argv){
         }
     omeeV=atof(argv[1]);
     
-    nanosphere ns;    
-    fstream nano, time, frlc, omga;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
-    frlc.open("../data/output/frohlich.dat", ios::out);
-    omga.open("../data/output/omega.dat", ios::out);
+    nanosphere ns;
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream frlc("../data/output/frohlich.dat");
+    if (!frlc) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream omga("../data/output/omega.dat");
+    if (!omga) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     time>>T>>tpump;    

--- a/src/nanoshell_omeG_p3.cxx
+++ b/src/nanoshell_omeG_p3.cxx
@@ -164,9 +164,16 @@ int main(){
     
     nanosphere ns;
     
-    fstream nano, cd4p;
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    cd4p.open("../data/output/oGp/data4plot.dat", ios::out);
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream cd4p("../data/output/oGp/data4plot.dat");
+    if (!cd4p) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     if (E0==0.) E0=1.e-30; // zero is problematic as a value for E0 
@@ -261,9 +268,16 @@ int main(){
     if(visok.size()!=0) complete(visok, omemi, omema, dome, 2.*fro[1]);
     else cout<<"frequency range not wide enough to calculate the eigenvalue zeroes"<<endl;
     
-    fstream isoa, isok;
-    isoa.open("../data/output/oGp/iso_al.dat", ios::out);
-    isok.open("../data/output/oGp/iso_ka.dat", ios::out);
+    ofstream isoa("../data/output/oGp/iso_al.dat");
+    if (!isoa) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream isok("../data/output/oGp/iso_ka.dat");
+    if (!isok) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
 
     for (int ii=0; ii<int(visoa.size()); ii++)
         isoa<<" "<<visoa[ii].first<<" "<<visoa[ii].second<<endl;
@@ -272,8 +286,11 @@ int main(){
         isok<<" "<<visok[ii].first<<" "<<visok[ii].second<<endl;
     isok.close();
     
-    fstream cemi;
-    cemi.open("../data/output/oGp/ome_G_p3.dat", ios::out);
+    ofstream cemi("../data/output/oGp/ome_G_p3.dat");
+    if (!cemi) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     GN=500;
     omemi=0.5;
     omema=8.;

--- a/src/nanoshell_ome_al_p3.cxx
+++ b/src/nanoshell_ome_al_p3.cxx
@@ -158,8 +158,11 @@ int main(){
     nanosphere ns;
     ns.init();
     
-    fstream nano;
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
 
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     
@@ -199,10 +202,21 @@ int main(){
         ome2 = (rzero.second < izero.second) ? rzero.second : izero.second;
         }
 
-    fstream cop3, coal, cext;
-    cop3.open("../data/output/oGp/ome_p3.dat", ios::out);
-    coal.open("../data/output/oGp/ome_al.dat", ios::out);
-    cext.open("../data/output/oGp/ome_ex.dat", ios::out);
+    ofstream cop3("../data/output/oGp/ome_p3.dat");
+    if (!cop3) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream coal("../data/output/oGp/ome_al.dat");
+    if (!coal) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream cext("../data/output/oGp/ome_ex.dat");
+    if (!cext) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     cext<<ome1<<" "<<ome2<<" "<<fro[0]<<" "<<kex1<<" "<<kex2<<endl;
 

--- a/src/nanoshell_ss_spe.cxx
+++ b/src/nanoshell_ss_spe.cxx
@@ -39,13 +39,27 @@ int main(int argc, char** argv){
     char mtl[16], mdl[16], hst[16], sol[16], active[16];
 
     
-    nanosphere ns;    
-    fstream nano, time, frlc, omga;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
-    frlc.open("../data/output/frohlich.dat", ios::out);
-    omga.open("../data/output/omega.dat", ios::out);
+    nanosphere ns;
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream frlc("../data/output/frohlich.dat");
+    if (!frlc) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream omga("../data/output/omega.dat");
+    if (!omga) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;
     time>>T>>tpump;    

--- a/src/numOme_gsl.cxx
+++ b/src/numOme_gsl.cxx
@@ -44,6 +44,10 @@ double nfindOme(int nfft, vector<complex<double>> wave, double dt){
     wavetable = gsl_fft_complex_wavetable_alloc (nfft);
     workspace = gsl_fft_complex_workspace_alloc (nfft);
     ofstream  wve("../data/output/wave.dat");
+    if (!wve) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     for (int i=0; i<nfft; i++) {
         REAL(data,i) = wave[i].real();

--- a/src/rho2ome_sp.cxx
+++ b/src/rho2ome_sp.cxx
@@ -43,9 +43,11 @@ int main(int argc, char ** argv){
   
   char mtl[16], mdl[16], sol[16], hst[16], active[16];
   nanosphere ns;
-  fstream nano, res3;  
-  
-  nano.open("../data/input/nanosphere_eV.dat", ios::in);
+  ifstream nano("../data/input/nanosphere_eV.dat");
+  if (!nano) {
+    cerr << "Error: Cannot open input file" << endl;
+    return 1;
+  }
 
   nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rap>>hst;
 

--- a/src/sfrohlich.cxx
+++ b/src/sfrohlich.cxx
@@ -37,10 +37,12 @@ int main(){
   
   char mtl[16], mdl[16], sol[16], active[16];
   nanosphere ns;
-  fstream nano, res3;  
+  ifstream nano("../data/input/nanosphere_eV.dat");
+  if (!nano) {
+    cerr << "Error: Cannot open input file" << endl;
+    return 1;
+  }
   
-  nano.open("../data/input/nanosphere_eV.dat", ios::in);
-
   nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0;
 
   ns.init();

--- a/src/single.cxx
+++ b/src/single.cxx
@@ -43,11 +43,17 @@ int main(int argc, char** argv){
         }
     omeeV=atof(argv[1]);
     
-    nanosphere ns;    
-    fstream nano, time;
-
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    time.open("../data/input/time.dat", ios::in);
+    nanosphere ns;
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ifstream time("../data/input/time.dat");
+    if (!time) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
 
 
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0;

--- a/src/single_omeG_p3.cxx
+++ b/src/single_omeG_p3.cxx
@@ -164,9 +164,16 @@ int main(){
     nanosphere ns;
     ns.init();
     
-    fstream nano, cd4p;
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
-    cd4p.open("../data/output/oGp/data4plot.dat", ios::out);
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
+    ofstream cd4p("../data/output/oGp/data4plot.dat");
+    if (!cd4p) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0;
     
@@ -253,9 +260,16 @@ int main(){
     complete(visoa, omemi, omema, dome, 2.*fro[1]);
     complete(visok, omemi, omema, dome, 2.*fro[1]);
     
-    fstream isoa, isok;
-    isoa.open("../data/output/oGp/iso_al.dat", ios::out);
-    isok.open("../data/output/oGp/iso_ka.dat", ios::out);
+    ofstream isoa("../data/output/oGp/iso_al.dat");
+    if (!isoa) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream isok("../data/output/oGp/iso_ka.dat");
+    if (!isok) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
     
     for (int ii=0; ii<int(visoa.size()); ii++)
         isoa<<" "<<visoa[ii].first<<" "<<visoa[ii].second<<endl;

--- a/src/single_ome_al_p3.cxx
+++ b/src/single_ome_al_p3.cxx
@@ -158,8 +158,11 @@ int main(){
     nanosphere ns;
     ns.init();
     
-    fstream nano;
-    nano.open("../data/input/nanosphere_eV.dat", ios::in);
+    ifstream nano("../data/input/nanosphere_eV.dat");
+    if (!nano) {
+        cerr << "Error: Cannot open input file" << endl;
+        return 1;
+    }
 
     nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0;
     
@@ -196,9 +199,21 @@ int main(){
         ome2 = (rzero.second < izero.second) ? rzero.second : izero.second;
         }
 
-    fstream cop3, coal, cext;
-    coal.open("../data/output/oGp/ome_al.dat", ios::out);
-    cext.open("../data/output/oGp/ome_ex.dat", ios::out);
+    ofstream cop3("../data/output/oGp/ome_p3.dat");
+    if (!cop3) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream coal("../data/output/oGp/ome_al.dat");
+    if (!coal) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
+    ofstream cext("../data/output/oGp/ome_ex.dat");
+    if (!cext) {
+        cerr << "Error: Cannot open output file" << endl;
+        return 1;
+    }
 
 
     cext<<ome1<<" "<<ome2<<" "<<fro[0]<<" "<<kex1<<" "<<kex2<<endl;

--- a/src/variables.cxx
+++ b/src/variables.cxx
@@ -37,9 +37,11 @@ int main(){
   
   char mtl[16], mdl[16], sol[16], hst[16], active[16];
   nanosphere ns;
-  fstream nano, res3;  
-  
-  nano.open("../data/input/nanosphere_eV.dat", ios::in);
+  ifstream nano("../data/input/nanosphere_eV.dat");
+  if (!nano) {
+    cerr << "Error: Cannot open input file" << endl;
+    return 1;
+  }
 
     
   nano>>ns.r1>>ns.Dome>>ns.ome_0>>ns.G>>omemi>>omema>>mtl>>mdl>>active>>sol>>E0>>rho>>hst;


### PR DESCRIPTION
## Summary
- standardize file opening using ifstream/ofstream constructors
- add error checks for all input/output files

## Testing
- `make -C tests` *(fails: armadillo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa1a48a588333b75b00ebb04bc6c8